### PR TITLE
remove unused manifest property and fix spelling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -78,8 +78,7 @@
             "actions": [
               {
                 "id": "action",
-                "type": "executeFunction",
-                "displayName": "action"
+                "type": "executeFunction"
               }
             ]
           }
@@ -105,14 +104,14 @@
                       {
                         "id": "msgReadOpenPaneButton",
                         "type": "button",
-                        "label": "Show Taskpane",
+                        "label": "Show Task Pane",
                         "icons": [
                           { "size": 16, "url": "https://localhost:3000/assets/icon-16.png" },
                           { "size": 32, "url": "https://localhost:3000/assets/icon-32.png" },
                           { "size": 80, "url": "https://localhost:3000/assets/icon-80.png" }
                         ],
                         "supertip": {
-                          "title": "Show Taskpane",
+                          "title": "Show Task Pane",
                           "description": "Opens a pane displaying all available properties."
                         },
                         "actionId": "TaskPaneRuntimeShow"


### PR DESCRIPTION
**Change Description**:

1. "displayName" is only used in add-ins that have custom keyboard shortcuts.
2. "task pane" should be 2 words in public strings

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
no

3. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
no

4. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
no

5. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.
no

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
